### PR TITLE
Bump Enzyme version and API to v0.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpointing"
 uuid = "eb46d486-4f9c-4c3d-b445-a617f2a2f1ca"
 authors = ["Michel Schanen <mschanen@anl.gov>", "Sri Hari Krishna Narayanan <snarayan@mcs.anl.gov>"]
-version = "0.6.3"
+version = "0.7.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -14,7 +14,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [compat]
 ChainRulesCore = "1"
 DataStructures = "0.18"
-Enzyme = "0.10"
+Enzyme = "0.11"
 HDF5 = "0.16"
 julia = "1.7"
 

--- a/examples/adtools.jl
+++ b/examples/adtools.jl
@@ -34,7 +34,7 @@ function Checkpointing.jacobian(tobedifferentiated, F_H, ::EnzymeADTool)
         fill!(dx, 0)
         fill!(y, 0)
         dy[i] = 1.0
-        autodiff(f, Duplicated(x,dx), Duplicated(y, dy))
+        autodiff(Reverse, f, Duplicated(x,dx), Duplicated(y, dy))
         J[i,:] = dx[:]
     end
     return J

--- a/src/Schemes/Online_r2.jl
+++ b/src/Schemes/Online_r2.jl
@@ -410,7 +410,7 @@ function checkpoint_struct_while(
             model_final = deepcopy(model)
             # Enzyme.autodiff(body, Duplicated(model,shadowmodel))
         elseif (next_action.actionflag == Checkpointing.uturn)
-            Enzyme.autodiff(body, Duplicated(model,shadowmodel))
+            Enzyme.autodiff(Reverse, body, Duplicated(model,shadowmodel))
             if haskey(storemap,next_action.iteration-1-1)
                 push!(freeindices, storemap[next_action.iteration-1-1])
                 delete!(storemap,next_action.iteration-1-1)

--- a/src/Schemes/Periodic.jl
+++ b/src/Schemes/Periodic.jl
@@ -81,7 +81,7 @@ function checkpoint_struct_for(
         end
         for j= alg.period:-1:1
             model = deepcopy(model_check_inner[j])
-            Enzyme.autodiff(body, Duplicated(model,shadowmodel))
+            Enzyme.autodiff(Reverse, body, Duplicated(model,shadowmodel))
         end
     end
     return model_final

--- a/src/Schemes/Revolve.jl
+++ b/src/Schemes/Revolve.jl
@@ -409,9 +409,9 @@ function checkpoint_struct_for(
         elseif (next_action.actionflag == Checkpointing.firstuturn)
             body(model)
             model_final =  deepcopy(model)
-            Enzyme.autodiff(body, Duplicated(model,shadowmodel))
+            Enzyme.autodiff(Reverse, body, Duplicated(model,shadowmodel))
         elseif (next_action.actionflag == Checkpointing.uturn)
-            Enzyme.autodiff(body, Duplicated(model,shadowmodel))
+            Enzyme.autodiff(Reverse, body, Duplicated(model,shadowmodel))
             if haskey(storemap,next_action.iteration-1-1)
                 delete!(storemap,next_action.iteration-1-1)
                 check=check-1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ include("../examples/adtools.jl")
     @testset "Testing Jacobian interface..." begin
         include("jacobian.jl")
     end
-    @testset "Test optcontrol" begin
+    @testset "Test optcontrol deprecated" begin
         @testset "AD Tool $adtool" for adtool in [EnzymeADTool(), ForwardDiffADTool(), ReverseDiffADTool(), ZygoteADTool()]
             @testset "Testing Revolve..." begin
                 include("../examples/deprecated/optcontrol.jl")

--- a/test/speelpenning.jl
+++ b/test/speelpenning.jl
@@ -13,7 +13,7 @@ function main()
 
     dx = zeros(n)
     dy = [1.0]
-    autodiff(speelpenning, Duplicated(y,dy), Duplicated(x,dx))
+    autodiff(Reverse, speelpenning, Duplicated(y,dy), Duplicated(x,dx))
     y = [0.0]
     speelpenning(y,x)
 


### PR DESCRIPTION
The update to Enzyme 11 makes see deprecated AD tools test fail for Enzyme. Will be looked into https://github.com/Argonne-National-Laboratory/Checkpointing.jl/issues/23.