### PR TITLE
Only trigger GC in between timesteps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpointing"
 uuid = "eb46d486-4f9c-4c3d-b445-a617f2a2f1ca"
 authors = ["Michel Schanen <mschanen@anl.gov>", "Sri Hari Krishna Narayanan <snarayan@mcs.anl.gov>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/Schemes/Revolve.jl
+++ b/src/Schemes/Revolve.jl
@@ -396,6 +396,7 @@ function checkpoint_struct_for(
     check = 0
     model_check = alg.storage
     model_final = []
+    GC.enable(false)
     while true
         next_action = next_action!(alg)
         if (next_action.actionflag == Checkpointing.store)
@@ -410,8 +411,10 @@ function checkpoint_struct_for(
             body(model)
             model_final =  deepcopy(model)
             Enzyme.autodiff(Reverse, body, Duplicated(model,shadowmodel))
+            GC.gc()
         elseif (next_action.actionflag == Checkpointing.uturn)
             Enzyme.autodiff(Reverse, body, Duplicated(model,shadowmodel))
+            GC.gc()
             if haskey(storemap,next_action.iteration-1-1)
                 delete!(storemap,next_action.iteration-1-1)
                 check=check-1
@@ -426,5 +429,6 @@ function checkpoint_struct_for(
             break
         end
     end
+    GC.enable(true)
     return model_final
 end


### PR DESCRIPTION
This avoids GC issues when the differentiated code of an iteration is running.