### PR TITLE
Support UnitRange for loops properly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Checkpointing"
 uuid = "eb46d486-4f9c-4c3d-b445-a617f2a2f1ca"
 authors = ["Michel Schanen <mschanen@anl.gov>", "Sri Hari Krishna Narayanan <snarayan@mcs.anl.gov>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Proper support where the iterators are correctly handled for a `UnitRange` (e.g. 1:10) loop. Now an error is thrown if a user does not use a UnitRange. The next kind of range to support would be `StepRange` (e.g. 1:10:50).